### PR TITLE
Fix/tao 8108/delivery sync fixes

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Tao Offline',
     'description' => 'An extension to assist the setup of an offline context. Setup synchronisation and encryption by test center identifier',
     'license' => 'GPL-2.0',
-    'version' => '2.2.0',
+    'version' => '2.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoTestCenter' => '>=3.15.0',

--- a/scripts/tools/PostSetup/Client/DetachDeliveryCreateListeners.php
+++ b/scripts/tools/PostSetup/Client/DetachDeliveryCreateListeners.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+namespace oat\taoOffline\scripts\tools\PostSetup\Client;
+
+use oat\oatbox\event\EventManager;
+use oat\oatbox\extension\InstallAction;
+use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
+use oat\taoProctoring\model\delivery\DeliverySyncService;
+use oat\taoDeliveryRdf\model\TestRunnerFeatures;
+
+class DetachDeliveryCreateListeners extends InstallAction
+{
+    /**
+     * @param $params
+     * @return \common_report_Report
+     * @throws \common_Exception
+     */
+    public function __invoke($params)
+    {
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(DeliveryCreatedEvent::class, [DeliverySyncService::SERVICE_ID, 'onDeliveryCreated']);
+        $eventManager->detach(DeliveryCreatedEvent::class, [TestRunnerFeatures::class, 'enableDefaultFeatures']);
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+
+        return \common_report_Report::createInfo('Default delivery values events detached.');
+    }
+}

--- a/scripts/tools/setup/SetupClientServer.php
+++ b/scripts/tools/setup/SetupClientServer.php
@@ -30,6 +30,7 @@ use oat\taoEncryption\scripts\tools\SetupEncryptedSyncResult;
 use oat\taoEncryption\scripts\tools\SetupEncryptedUser;
 use oat\taoEncryption\scripts\tools\SetupUserSynchronizer;
 use oat\taoOffline\scripts\tools\byOrganisationId\SetupSyncFormByOrgId;
+use oat\taoOffline\scripts\tools\PostSetup\Client\DetachDeliveryCreateListeners;
 use oat\taoOffline\scripts\tools\PostSetup\Client\SwitchLockoutOff;
 use oat\taoSync\scripts\install\AttachReactivateDeliveryExecutionEvent;
 use oat\taoSync\scripts\tool\RegisterHandShakeAuthAdapter;
@@ -79,6 +80,7 @@ class SetupClientServer extends ScriptAction
         $report->add($this->runScript(SetupClientSynchronisationHistory::class));
         $report->add($this->runScript(RegisterClientSyncLogListener::class));
         $report->add($this->runScript(RegisterSyncStatusListener::class));
+        $report->add($this->runScript(DetachDeliveryCreateListeners::class));
 
         return $report;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -24,6 +24,6 @@ class Updater extends \common_ext_ExtensionUpdater
 {
     public function update($initialVersion)
     {
-        $this->skip('0.1.0', '2.2.0');
+        $this->skip('0.1.0', '2.2.1');
     }
 }


### PR DESCRIPTION
Default delivery values events detached

Steps to reproduce:
1 Create delivery on server
2 Uncheck Test Runner Features and Require Proctoring checkboxes
3 Run synchronization with a client and check new delivery on the client

Actual result: Test Runner Features and Require Proctoring checkboxes will be checked
Expected result: Test Runner Features and Require Proctoring checkboxes unchecked
