### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,6 +30,7 @@ return array(
     'version' => '2.5.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
+        'generis'       => '>=12.5.0',
         'taoTestCenter' => '>=8.2.0',
         'taoSync'       => '>=4.2.0',
         'taoPublishing' => '>=2.1.1',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Tao Offline',
     'description' => 'An extension to assist the setup of an offline context. Setup synchronisation and encryption by test center identifier',
     'license' => 'GPL-2.0',
-    'version' => '2.5.0',
+    'version' => '3.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'       => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Tao Offline',
     'description' => 'An extension to assist the setup of an offline context. Setup synchronisation and encryption by test center identifier',
     'license' => 'GPL-2.0',
-    'version' => '2.4.2',
+    'version' => '2.5.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoTestCenter' => '>=8.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -74,6 +74,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.3.0');
         }
 
-        $this->skip('2.3.0', '2.5.0');
+        $this->skip('2.3.0', '3.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -74,6 +74,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.3.0');
         }
 
-        $this->skip('2.3.0', '2.4.2');
+        $this->skip('2.3.0', '2.5.0');
     }
 }

--- a/test/unit/model/import/TestCenterMapperTest.php
+++ b/test/unit/model/import/TestCenterMapperTest.php
@@ -24,12 +24,12 @@ use oat\tao\model\import\service\MandatoryFieldException;
 use oat\taoOffline\model\import\TestCenterMapper;
 use oat\taoOffline\model\import\UniqueFieldException;
 use oat\taoOffline\model\service\TaoOfflineTestCenterFormService;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class TestCenterMapperTest extends TestCase
 {
     /**
-     * @var TaoOfflineTestCenterFormService|PHPUnit_Framework_MockObject_MockObject
+     * @var TaoOfflineTestCenterFormService|MockObject
      */
     private $serviceMock;
 

--- a/test/unit/model/service/TestCenterFormServiceTest.php
+++ b/test/unit/model/service/TestCenterFormServiceTest.php
@@ -24,17 +24,17 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
 use oat\generis\test\TestCase;
 use oat\taoOffline\model\service\TaoOfflineTestCenterFormService;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class TestCenterFormServiceTest extends TestCase
 {
     /**
-     * @var TaoOfflineTestCenterFormService|PHPUnit_Framework_MockObject_MockObject
+     * @var TaoOfflineTestCenterFormService|MockObject
      */
     private $serviceMock;
 
     /**
-     * @var core_kernel_classes_Class|PHPUnit_Framework_MockObject_MockObject
+     * @var core_kernel_classes_Class|MockObject
      */
     private $classMock;
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.