### PR TITLE
Fix TR-1439: Sync Server set-up script

### DIFF
--- a/scripts/tools/byOrganisationId/RegisterSyncServiceByOrgId.php
+++ b/scripts/tools/byOrganisationId/RegisterSyncServiceByOrgId.php
@@ -27,7 +27,6 @@ use oat\generis\model\WidgetRdf;
 use oat\oatbox\extension\InstallAction;
 use oat\tao\helpers\form\ValidationRuleRegistry;
 use oat\tao\model\TaoOntology;
-use oat\tao\model\WidgetDefinitions;
 use oat\taoDeliveryRdf\model\ContainerRuntime;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoSync\model\Entity;
@@ -41,6 +40,7 @@ use oat\taoSync\model\synchronizer\AbstractResourceSynchronizer;
 use oat\taoSync\model\synchronizer\testcenter\TestCenterSynchronizer;
 use oat\taoSync\model\SyncService;
 use oat\taoTestCenter\model\TestCenterService;
+use tao_helpers_form_elements_Textbox as TextBox;
 
 /**
  * Class RegisterSyncService
@@ -88,7 +88,7 @@ class RegisterSyncServiceByOrgId extends InstallAction
         $property->setLgDependent(false);
         $property->setPropertiesValues(array(
             ValidationRuleRegistry::PROPERTY_VALIDATION_RULE => 'notEmpty',
-            WidgetRdf::PROPERTY_WIDGET => WidgetDefinitions::PROPERTY_TEXTBOX,
+            WidgetRdf::PROPERTY_WIDGET => TextBox::WIDGET_ID,
             TaoOntology::PROPERTY_GUI_ORDER => 1,
         ));
     }


### PR DESCRIPTION
# [TR-1439](https://oat-sa.atlassian.net/browse/TR-1439)

fix: Sync Server set-up script by replacing `oat\tao\model\WidgetDefinitions` constants usage with FormElement widget IDs

## How to test

1. Install `taoOffline` by running requiring the extension and running `php ./tao/scripts/intallExtension.php taoOffline`
2. Run `php index.php 'oat\taoOffline\scripts\tools\setup\SetupCentralServer'` to set up the TAO instance as a Central Server

ℹ️ This unblocks [TR-1440](https://oat-sa.atlassian.net/browse/TR-1440)